### PR TITLE
Fixing broken url of sweet.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 <h3 id="roadmap">Roadmap</h3>
 <p>Upcoming jtmpl 0.4.0 will be a complete rewrite. Here&#39;s what&#39;s changing:</p>
 <h4 id="source-language">Source language</h4>
-<p>New language is JavaScript, augmented with <a href="sweetjs.org">Sweet.js</a>, <a href="https://github.com/jlongster/es6-macros">es6macros</a> and <a href="https://github.com/natefaubion/sparkler">sparkler</a>. CoffeeScript is an excellent prototyping language and helped develop the idea. JavaScript base would be more accessible and can be shaped with macros to fit closely jtmpl needs. </p>
+<p>New language is JavaScript, augmented with <a href="http://sweetjs.org">Sweet.js</a>, <a href="https://github.com/jlongster/es6-macros">es6macros</a> and <a href="https://github.com/natefaubion/sparkler">sparkler</a>. CoffeeScript is an excellent prototyping language and helped develop the idea. JavaScript base would be more accessible and can be shaped with macros to fit closely jtmpl needs. </p>
 <h4 id="eliminate-the-compiler">Eliminate the compiler</h4>
 <p>The compiler is a major piece of complexity and code volume. Every browser already includes a HTML parser that can be leveraged. So compiler will be removed completely, Mustache tags will be parsed from the constructed (offline) DOM tree instead &ndash; a much simpler approach.</p>
 <h4 id="immutable-structures">Immutable structures</h4>


### PR DESCRIPTION
"New language is JavaScript, augmented with [Sweet.js], es6macros and sparkler. CoffeeScript is an excellent..." links to http://jtmpl.com/sweetjs.org instead of http://sweetjs.org/
